### PR TITLE
Upstream merge of Debian 2.42.1 packaging (no quilt patches)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,209 @@
-glib2.0 (2.40.0-3endless1) unstable; urgency=low
+glib2.0 (2.42.1-1endless1) unstable; urgency=medium
+
+  [ Iain Lane ]
+  * Pass --enable-debug=minimum not minimal - this is what configure.ac
+    expects.
+
+  [ Emilio Pozuelo Monfort ]
+  * New upstream bugfix release.
+  * d/p/0001-properties-disable-default-deprecation-warnings.patch:
+    + Removed, merged upstream.
+
+ -- Emilio Pozuelo Monfort <pochu@debian.org>  Tue, 11 Nov 2014 18:53:49 +0100
+
+glib2.0 (2.42.0-2) unstable; urgency=medium
+
+  [ Andreas Henriksson ]
+  * Update Vcs-* to use unstable instead of experimental branch
+
+  [ Iain Lane ]
+  * 0001-properties-disable-default-deprecation-warnings.patch: Backport from
+    upstream stable branch - silences warnings that are shown to users on
+    stderr, and which also cause some testsuite failures and consequent FTBFS.
+
+ -- Iain Lane <laney@debian.org>  Thu, 02 Oct 2014 13:08:24 +0100
+
+glib2.0 (2.42.0-1) unstable; urgency=medium
+
+  * New upstream release
+
+ -- Iain Lane <iain@orangesquash.org.uk>  Tue, 23 Sep 2014 10:12:15 +0100
+
+glib2.0 (2.41.5-2) unstable; urgency=medium
+
+  * Upload to unstable.
+
+ -- Andreas Henriksson <andreas@fatal.se>  Fri, 19 Sep 2014 22:00:33 +0200
+
+glib2.0 (2.41.5-1) experimental; urgency=medium
+
+  [ Andreas Henriksson ]
+  * Make libglib2.0-0 recommend xdg-user-dirs
+    - needed to set up ~/.config/user-dirs.dirs to get default XDG_*_DIR set.
+
+  [ Iain Lane ]
+  * New upstream release 2.41.5
+    - GDesktopAppInfo: avoid polling on missing desktop dirs
+
+ -- Iain Lane <iain@orangesquash.org.uk>  Wed, 17 Sep 2014 10:19:27 +0100
+
+glib2.0 (2.41.4-1) experimental; urgency=medium
+
+  * New upstream release
+  * debian/libglib2.0-0.symbols:
+    + Add g_application_add_main_option symbol
+
+ -- Sjoerd Simons <sjoerd@debian.org>  Sat, 06 Sep 2014 15:16:14 +0200
+
+glib2.0 (2.41.3-1) experimental; urgency=medium
+
+  * New upstream release 2.41.3
+  * debian/tests/installed-tests: Revert the previous change - require dbus >=
+    1.8 and always use dbus-run-session.
+
+ -- Iain Lane <iain@orangesquash.org.uk>  Wed, 20 Aug 2014 16:16:23 +0100
+
+glib2.0 (2.41.2-1) experimental; urgency=medium
+
+  * New upstream release
+    - The Unicode support has been updated to version 7.0 of the Unicode
+      standard
+    - GNotification now supports priorities for notifications
+    - GMutex now uses a faster, native implementation on Linux
+  * 0001-gvariant-tests-workaround-libc-compiler-issue.patch: Drop, applied
+    upstream in this release.
+  * Add new symbols for this release.
+  * Merge in changes from 2.40.0-4
+    + Adapt for system pcre3/1:8.35 (Closes: #755439):
+      - a PCRE 8.31 bug in case-insensitivity has been fixed, so do not assert
+        bug-for-bug compatibility with 8.31
+      - named match groups' names cannot start with a digit any more, so
+        (?P<1>.) is no longer allowed; do not assert that it is
+      - turn off a new optimization that would reduce the result set when
+        called from g_match_all(_full), to preserve existing functionality
+    + Build-depend on pcre3/1:8.35 so that the new optimization is
+      known to be turned off in the built binaries
+    + Add patch from upstream to fix mis-optimization in gvariant test
+      with gcc 4.9 (Closes: #756272)
+    + Avoid using dbus-launch for regression tests (Closes: #737488):
+      - run installed-tests under dbus-run-session from dbus (>= 1.8)
+      - do not run build-time tests under dbus-launch: those that use D-Bus
+        all create their own session bus instances now
+        (i.e. remove 05_run-gio-tests-with-a-dbus-session.patch)
+      - set a deliberately invalid DBUS_SESSION_BUS_ADDRESS to make sure
+        nothing in the build is still inheriting it from the environment
+    + Override Lintian false positive #733733: we build-depend on python:any
+      but Lintian doesn't yet understand :any syntax
+  * Make the installed tests still run dbus-launch if we don't have
+    dbus-run-session (i.e. if the installed dbus is << 1.8).
+
+ -- Iain Lane <laney@debian.org>  Thu, 14 Aug 2014 11:14:40 +0100
+
+glib2.0 (2.41.1-2) experimental; urgency=medium
+
+  * 0001-gvariant-tests-workaround-libc-compiler-issue.patch: Cherry-pick
+    patch from upstream to fix/workaround a new compiler optimisation in
+    gcc-4.9 which occurs when passing a null pointer / zero size to memcmp.
+    Should fix FTBFS on many arches in unstable.
+
+ -- Iain Lane <iain@orangesquash.org.uk>  Wed, 25 Jun 2014 10:21:27 +0100
+
+glib2.0 (2.41.1-1) experimental; urgency=medium
+
+  * New upstream release
+  * 0001-Prevent-an-invalid-CARBON_LIBS-from-appearing-in-the.patch: Drop,
+    included in this release.
+  * Update symbols file with the new symbol in this release.
+
+ -- Iain Lane <iain@orangesquash.org.uk>  Tue, 24 Jun 2014 12:40:29 +0100
+
+glib2.0 (2.41.0-2) experimental; urgency=medium
+
+  [ Andreas Henriksson ]
+  * Bump python:any build-dependency to >= 2.7.5-5~ (Closes: #747928)
+
+  [ Emilio Pozuelo Monfort ]
+  * Use the default compiler on sparc, since it's already >> 4.7.
+    Closes: #751313.
+
+  [ Iain Lane ]
+  * 0001-Prevent-an-invalid-CARBON_LIBS-from-appearing-in-the.patch:
+    Cherry-pick patch from upstream to fix an invalid "@CARBON_LIBS@" token
+    appearing in Libs.private in the pcfile. (LP: #1330033)
+
+ -- Iain Lane <laney@debian.org>  Mon, 16 Jun 2014 10:17:36 +0100
+
+glib2.0 (2.41.0-1) experimental; urgency=medium
+
+  [ Emilio Pozuelo Monfort ]
+  * debian/libglib2.0-doc.links:
+    + The symlink for the gtk docs is broken at the moment, and even if
+      fixed, it will still be broken if libgtk2.0-doc isn't installed on
+      a system, so just drop it. Closes: #746782.
+
+  [ Iain Lane ]
+  * New upstream release 2.41.0
+    - Many bugfixes found by static analysis, including potential fd leaks and
+      NULL pointer dereferences.
+    - Increased use of (nullable) attribute on out values and return types now
+      that it is supported (mostly from porting Vala metadata).
+    - use XDG_CURRENT_DESKTOP for OnlyShowIn/NotShowIn handling of desktop
+      files, deprecating g_desktop_app_info_set_desktop_env()
+    - add support for g_desktop_app_info_get_implementations() to find desktop
+      files that have an Implements= line for a given interface
+    - GHmac has gained SHA-512 support
+    - support the new mimeapps specification (most notably, moving the
+      assoications/defaults configuration to ~/.config/mimeapps.list).
+    - libgobject is now linked -Wl,-z,nodelete when possible to avoid errors
+      when gobject is used from a module for a program that does not itself use
+      gobject and that module is unloaded/reloaded
+  * debian/watch: Use http://ftp.gnome.org; it's more up-to-date.
+  * Update symbols file with new symbols for this release.
+
+ -- Iain Lane <laney@debian.org>  Tue, 27 May 2014 15:41:46 +0100
+
+glib2.0 (2.40.0-4) unstable; urgency=medium
+
+  * Team upload
+
+  [ Emilio Pozuelo Monfort ]
+  * Use the default compiler on sparc, since it's already >> 4.7.
+    Closes: #751313.
+
+  [ Iain Lane ]
+  * Fix Vcs-* for the unstable branches
+
+  [ Simon McVittie ]
+  * Adapt for system pcre3/1:8.35 (Closes: #755439):
+    - a PCRE 8.31 bug in case-insensitivity has been fixed, so do not assert
+      bug-for-bug compatibility with 8.31
+    - named match groups' names cannot start with a digit any more, so
+      (?P<1>.) is no longer allowed; do not assert that it is
+    - turn off a new optimization that would reduce the result set when called
+      from g_match_all(_full), to preserve existing functionality
+  * Build-depend on pcre3/1:8.35 so that the new optimization is
+    known to be turned off in the built binaries
+  * Add patch from upstream to fix mis-optimization in gvariant test
+    with gcc 4.9 (Closes: #756272)
+  * Avoid using dbus-launch for regression tests (Closes: #737488):
+    - run installed-tests under dbus-run-session from dbus (>= 1.8)
+    - do not run build-time tests under dbus-launch: those that use D-Bus
+      all create their own session bus instances now
+      (i.e. remove 05_run-gio-tests-with-a-dbus-session.patch)
+    - set a deliberately invalid DBUS_SESSION_BUS_ADDRESS to make sure
+      nothing in the build is still inheriting it from the environment
+  * Override Lintian false positive #733733: we build-depend on python:any
+    but Lintian doesn't yet understand :any syntax
+
+ -- Simon McVittie <smcv@debian.org>  Sun, 10 Aug 2014 22:58:33 +0100
+
+glib2.0 (2.40.0-3) unstable; urgency=medium
 
   [ Rico Tzschichholz ]
   * debian/libglib2.0-bin.install:
     - Install /usr/bin/gapplication
 
- -- Víctor Jáquez <vjaquez@igalia.com>  Fri, 02 May 2014 13:24:49 +0200
+ -- Sjoerd Simons <sjoerd@debian.org>  Sun, 27 Apr 2014 10:36:34 +0200
 
 glib2.0 (2.40.0-2endless1) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -2,18 +2,17 @@ Source: glib2.0
 Section: libs
 Priority: optional
 Maintainer: Debian GNOME Maintainers <pkg-gnome-maintainers@lists.alioth.debian.org>
-Uploaders: Andreas Henriksson <andreas@fatal.se>, Emilio Pozuelo Monfort <pochu@debian.org>
+Uploaders: Andreas Henriksson <andreas@fatal.se>, Emilio Pozuelo Monfort <pochu@debian.org>, Iain Lane <laney@debian.org>, Sjoerd Simons <sjoerd@debian.org>
 Build-Depends: debhelper (>= 9),
                cdbs (>= 0.4.93),
                dh-autoreconf,
-               gcc-4.8 [sparc],
                pkg-config (>= 0.16.0),
                gettext,
                autotools-dev,
                gnome-pkg-tools (>= 0.11),
                dpkg-dev (>= 1.16.0),
                libelfg0-dev (>= 0.8.12),
-               libpcre3-dev (>= 1:8.31),
+               libpcre3-dev (>= 1:8.35),
                desktop-file-utils,
                gtk-doc-tools (>= 1.20),
                libselinux1-dev [linux-any],
@@ -24,15 +23,15 @@ Build-Depends: debhelper (>= 9),
                dbus-x11,
                shared-mime-info,
                xterm,
-               python:any (>= 2.6.6-3~),
+               python:any (>= 2.7.5-5~),
                python-dbus,
                python-gi,
                libxml2-utils,
                libffi-dev (>= 3.0.0)
 Standards-Version: 3.9.5
 Homepage: http://www.gtk.org/
-Vcs-Browser: http://anonscm.debian.org/viewvc/pkg-gnome/desktop/experimental/glib2.0/
-Vcs-Svn: svn://anonscm.debian.org/pkg-gnome/desktop/experimental/glib2.0/
+Vcs-Browser: http://anonscm.debian.org/viewvc/pkg-gnome/desktop/unstable/glib2.0/
+Vcs-Svn: svn://anonscm.debian.org/pkg-gnome/desktop/unstable/glib2.0/
 XS-Testsuite: autopkgtest
 
 Package: libglib2.0-0
@@ -40,7 +39,8 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends}
 Recommends: libglib2.0-data,
-            shared-mime-info
+            shared-mime-info,
+            xdg-user-dirs
 Breaks: gvfs (<< 1.8),
         glib-networking (<< 2.33.12),
         python-gi (<< 3.7.2),

--- a/debian/control.in
+++ b/debian/control.in
@@ -6,14 +6,13 @@ Uploaders: @GNOME_TEAM@
 Build-Depends: debhelper (>= 9),
                cdbs (>= 0.4.93),
                dh-autoreconf,
-               gcc-4.8 [sparc],
                pkg-config (>= 0.16.0),
                gettext,
                autotools-dev,
                gnome-pkg-tools (>= 0.11),
                dpkg-dev (>= 1.16.0),
                libelfg0-dev (>= 0.8.12),
-               libpcre3-dev (>= 1:8.31),
+               libpcre3-dev (>= 1:8.35),
                desktop-file-utils,
                gtk-doc-tools (>= 1.20),
                libselinux1-dev [linux-any],
@@ -24,15 +23,15 @@ Build-Depends: debhelper (>= 9),
                dbus-x11,
                shared-mime-info,
                xterm,
-               python:any (>= 2.6.6-3~),
+               python:any (>= 2.7.5-5~),
                python-dbus,
                python-gi,
                libxml2-utils,
                libffi-dev (>= 3.0.0)
 Standards-Version: 3.9.5
 Homepage: http://www.gtk.org/
-Vcs-Browser: http://anonscm.debian.org/viewvc/pkg-gnome/desktop/experimental/glib2.0/
-Vcs-Svn: svn://anonscm.debian.org/pkg-gnome/desktop/experimental/glib2.0/
+Vcs-Browser: http://anonscm.debian.org/viewvc/pkg-gnome/desktop/unstable/glib2.0/
+Vcs-Svn: svn://anonscm.debian.org/pkg-gnome/desktop/unstable/glib2.0/
 XS-Testsuite: autopkgtest
 
 Package: @SHARED_PKG@
@@ -40,7 +39,8 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends}
 Recommends: @DATA_PKG@,
-            shared-mime-info
+            shared-mime-info,
+            xdg-user-dirs
 Breaks: gvfs (<< 1.8),
         glib-networking (<< 2.33.12),
         python-gi (<< 3.7.2),

--- a/debian/libglib2.0-0.symbols
+++ b/debian/libglib2.0-0.symbols
@@ -77,6 +77,7 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_app_launch_context_setenv@Base 2.31.8
  g_app_launch_context_unsetenv@Base 2.31.8
  g_application_activate@Base 2.28.0
+ g_application_add_main_option@Base 2.41.4
  g_application_add_main_option_entries@Base 2.39.90
  g_application_add_option_group@Base 2.39.90
  g_application_command_line_create_file_for_arg@Base 2.35.8
@@ -102,6 +103,7 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_application_get_inactivity_timeout@Base 2.28.0
  g_application_get_is_registered@Base 2.28.0
  g_application_get_is_remote@Base 2.28.0
+ g_application_get_resource_base_path@Base 2.41.2
  g_application_get_type@Base 2.28.0
  g_application_hold@Base 2.28.0
  g_application_id_is_valid@Base 2.28.0
@@ -118,6 +120,7 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_application_set_default@Base 2.31.8
  g_application_set_flags@Base 2.28.0
  g_application_set_inactivity_timeout@Base 2.28.0
+ g_application_set_resource_base_path@Base 2.41.2
  g_application_unmark_busy@Base 2.37.0
  g_application_withdraw_notification@Base 2.39.4
  g_ask_password_flags_get_type@Base 2.16.0
@@ -555,6 +558,7 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_desktop_app_info_get_categories@Base 2.30.0
  g_desktop_app_info_get_filename@Base 2.24.0
  g_desktop_app_info_get_generic_name@Base 2.30.0
+ g_desktop_app_info_get_implementations@Base 2.41.0
  g_desktop_app_info_get_is_hidden@Base 2.16.0
  g_desktop_app_info_get_keywords@Base 2.31.8
  g_desktop_app_info_get_nodisplay@Base 2.30.0
@@ -1141,11 +1145,13 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_notification_add_button_with_target_value@Base 2.39.4
  g_notification_get_type@Base 2.39.4
  g_notification_new@Base 2.39.4
+ g_notification_priority_get_type@Base 2.41.2
  g_notification_set_body@Base 2.39.4
  g_notification_set_default_action@Base 2.39.4
  g_notification_set_default_action_and_target@Base 2.39.4
  g_notification_set_default_action_and_target_value@Base 2.39.4
  g_notification_set_icon@Base 2.39.4
+ g_notification_set_priority@Base 2.41.2
  g_notification_set_title@Base 2.39.4
  g_notification_set_urgent@Base 2.39.4
  g_null_settings_backend_new@Base 2.28.0
@@ -3771,6 +3777,7 @@ libgobject-2.0.so.0 libglib2.0-0 #MINVER#
  g_type_check_instance@Base 2.12.0
  g_type_check_instance_cast@Base 2.12.0
  g_type_check_instance_is_a@Base 2.12.0
+ g_type_check_instance_is_fundamentally_a@Base 2.41.1
  g_type_check_is_value_type@Base 2.12.0
  g_type_check_value@Base 2.12.0
  g_type_check_value_holds@Base 2.12.0
@@ -3878,6 +3885,7 @@ libgobject-2.0.so.0 libglib2.0-0 #MINVER#
  g_value_get_ulong@Base 2.12.0
  g_value_get_variant@Base 2.26.0
  g_value_init@Base 2.12.0
+ g_value_init_from_instance@Base 2.41.2
  g_value_peek_pointer@Base 2.12.0
  g_value_register_transform_func@Base 2.12.0
  g_value_reset@Base 2.12.0

--- a/debian/libglib2.0-doc.links
+++ b/debian/libglib2.0-doc.links
@@ -1,4 +1,3 @@
-usr/share/doc/libgtk2.0-doc/gtk usr/share/doc/libglib2.0-doc/gtk
 usr/share/doc/libglib2.0-doc/gio usr/share/gtk-doc/html/gio
 usr/share/doc/libglib2.0-doc/glib usr/share/gtk-doc/html/glib
 usr/share/doc/libglib2.0-doc/gobject usr/share/gtk-doc/html/gobject

--- a/debian/rules
+++ b/debian/rules
@@ -64,6 +64,10 @@ DEB_DH_TRANSLATIONS_ARGS = -Xinstalled-tests
 # where creating /home/buildd/.dbus-keyrings fails
 export HOME=$(CURDIR)/debian/build
 
+# Make sure that everything that uses D-Bus is creating its own temporary
+# session rather than polluting the developer's (or failing, on buildds)
+export DBUS_SESSION_BUS_ADDRESS=this-should-not-be-used-and-will-fail:
+
 ifeq ($(DEB_HOST_ARCH_OS), linux)
   DEB_MAKE_CHECK_TARGET = $(if $(filter deb, $(cdbs_make_curflavor)), -k check -j1)
 else
@@ -87,16 +91,13 @@ ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
 			--disable-modular-tests \
 			--disable-gtk-doc
 endif
-ifeq ($(DEB_HOST_ARCH), sparc)
-  DEB_CONFIGURE_EXTRA_FLAGS += CC=gcc-4.8
-endif
 
 DEB_CONFIGURE_FLAGS_deb := \
 			--enable-gtk-doc \
 			--enable-static \
 			--enable-installed-tests \
 			--enable-always-build-tests \
-			--enable-debug=minimal
+			--enable-debug=minimum
 
 DEB_CONFIGURE_FLAGS_udeb := \
 			--disable-selinux

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -2,4 +2,4 @@ Tests: build
 Depends: libglib2.0-dev, build-essential
 
 Tests: installed-tests
-Depends: libglib2.0-tests, dbus-x11, xauth, xvfb, gnome-desktop-testing
+Depends: libglib2.0-tests, dbus-x11, dbus (>= 1.8), xauth, xvfb, gnome-desktop-testing

--- a/debian/tests/installed-tests
+++ b/debian/tests/installed-tests
@@ -7,4 +7,4 @@ set -e
 
 export XDG_RUNTIME_DIR=$ADTTMP
 
-dbus-launch xvfb-run -a gnome-desktop-testing-runner glib
+dbus-run-session -- xvfb-run -a gnome-desktop-testing-runner glib

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
 version=3
-http://download.gnome.org/sources/glib/([\d\.]+)/ \
+http://ftp.gnome.org/pub/GNOME/sources/glib/([\d\.]+)/ \
 	glib-(.*)\.tar\.xz


### PR DESCRIPTION
Source has been updated with changes from git and we use the Debian
packaging data here to match those up.

[endlessm/eos-shell#3276]
