### PR TITLE
GAsyncInitable: Fix leaked object when using _newv_async

### DIFF
--- a/gio/gasyncinitable.c
+++ b/gio/gasyncinitable.c
@@ -379,6 +379,7 @@ g_async_initable_newv_async (GType                object_type,
   g_async_initable_init_async (G_ASYNC_INITABLE (obj),
 			       io_priority, cancellable,
 			       callback, user_data);
+  g_object_unref (obj); /* Passed ownership to async call */
 }
 
 /**


### PR DESCRIPTION
[endlessm/eos-shell#5438]
