### PR TITLE
goutputstream: report input stream read failure correctly

### DIFF
--- a/gio/goutputstream.c
+++ b/gio/goutputstream.c
@@ -605,7 +605,8 @@ g_output_stream_real_splice (GOutputStream             *stream,
   if (flags & G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET)
     {
       /* But write errors on close are bad! */
-      res = g_output_stream_internal_close (stream, cancellable, error);
+      if (!g_output_stream_internal_close (stream, cancellable, error))
+        res = FALSE;
     }
 
   if (res)


### PR DESCRIPTION
When G_OUTPUT_STREAM_CLOSE_TARGET is set,
g_output_stream_real_splice was not returning -1 in any error
cases, since the success flag was being overwritten.

endlessm/eos-shell#5640
