### PR TITLE
Revert "Adjust path to glib-compile-schemas in the pkg-config file"

### DIFF
--- a/gio-2.0.pc.in
+++ b/gio-2.0.pc.in
@@ -4,8 +4,8 @@ libdir=@libdir@
 includedir=@includedir@
 
 giomoduledir=@GIO_MODULE_DIR@
-glib_compile_schemas=@libdir@/glib-2.0/glib-compile-schemas
-glib_compile_resources=@libdir@/glib-2.0/glib-compile-resources
+glib_compile_schemas=glib-compile-schemas
+glib_compile_resources=glib-compile-resources
 gdbus_codegen=gdbus-codegen
 
 Name: GIO


### PR DESCRIPTION
This reverts commit 0916e0ae1da0e7d7ab39a2254bbd74cc1577b9c2.

[endlessm/eos-shell#5734]
