### PR TITLE
Upgrade to 2.48.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,116 @@
-glib2.0 (2.46.2-0) master; urgency=medium
+glib2.0 (2.48.0-0) master; urgency=medium
 
   * Endless release. We are forcing a lower version for jenkins.
 
- -- Matt Watson <mattdangerw@gmail.com>  Thu, 07 Jan 2016 16:28:34 -0800
+ -- Philip Chimento <philip@endlessm.com>  Mon, 25 Apr 2016 15:51:04 -0700
+
+glib2.0 (2.48.0-1) unstable; urgency=medium
+
+  * New upstream stable release 2.48.0
+    + a minor build fix in the name of determinism (Closes: #812876)
+    + a few coverity fixes
+
+ -- Iain Lane <laney@debian.org>  Wed, 23 Mar 2016 17:59:23 +0000
+
+glib2.0 (2.47.92-1) experimental; urgency=medium
+
+  * New upstream release.
+
+ -- Andreas Henriksson <andreas@fatal.se>  Wed, 16 Mar 2016 11:18:53 +0100
+
+glib2.0 (2.47.6-1) experimental; urgency=medium
+
+  * New upstream release.
+    - GString is missing (transfer none) annotations on many of its methods
+    - systemtap and gdb scripts install in wrong place
+    - Documentation: various small improvements
+    - gdbusobjectmanagerserver: Clarify recommended ObjectManager paths
+    - Fix some annotations
+    - Cannot build with default flags under Fedora rawhide
+      (-Werror=format-nonliteral)
+    - gmacros.h is testing attributes with __has_feature (when compiling with
+      clang)
+  * debian/libglib2.0-0-dbg.install.in: Upstream now installs the gdb
+    auto-loaded scripts in the right place by themselves - no need for us to
+    move them about.
+
+ -- Iain Lane <laney@debian.org>  Thu, 18 Feb 2016 14:07:22 +0000
+
+glib2.0 (2.47.5-1) experimental; urgency=medium
+
+  * debian/watch: Use download.gnome.org, seems ftp.gnome.org is not updating
+    properly currently.
+  * New upstream release 2.47.5
+    + the system copy of PCRE is now used by default to implement GRegex.
+      Configure with --with-pcre=internal if a system PCRE version
+      is unavailable or undesired.
+    + interfaces for DTLS support have been added. A new version of
+      glib-networking will also be required.
+    + GDBusMethodInvocation now drops replies if the sender set the
+      NO_REPLY_EXPECTED flag
+    + several GApplication fixes, including fixes for commandline arguments in
+      interpreted languages on Windows
+  * debian/libglib2.0-0.symbols: Update with new symbols for this release.
+  * 0001-regex-test-expect-ASSERTION_EXPECTED-for-ab-with-PCR.patch: Drop,
+    it's included in this release.
+
+ -- Iain Lane <laney@debian.org>  Wed, 20 Jan 2016 17:55:16 +0000
+
+glib2.0 (2.47.4-1) experimental; urgency=medium
+
+  * New upstream release
+    + The GApplication documentation has been improved in several areas.
+  * 0001-tests-fix-a-test-on-32-bit-builds.patch,
+    0001-gtypes.h-move-G_STATIC_ASSERT-to-function-scope.patch: Drop, applied
+    upstream in this release.
+  * 0001-regex-test-expect-ASSERTION_EXPECTED-for-ab-with-PCR.patch: Fix regex
+    tests to assert the right errors as of pcre 8.38. Cherry-pick from
+    upstream. (Closes: #808842)
+  * Don't build automatic dbgsym package for -refdbg
+
+ -- Iain Lane <laney@debian.org>  Thu, 14 Jan 2016 18:27:02 +0000
+
+glib2.0 (2.47.3-3) experimental; urgency=medium
+
+  * debian/patches/0001-gtypes.h-move-G_STATIC_ASSERT-to-function-scope.patch:
+    Another cherry-pick. Should fix g-ir-scanner.
+
+ -- Iain Lane <laney@debian.org>  Sun, 29 Nov 2015 18:45:29 +0000
+
+glib2.0 (2.47.3-2) experimental; urgency=medium
+
+  * debian/patches/0001-tests-fix-a-test-on-32-bit-builds.patch: Cherry-pick
+    from upstream. Fix tests (and therefore the build) on 32 bit arches.
+
+ -- Iain Lane <laney@debian.org>  Thu, 26 Nov 2015 16:12:12 +0000
+
+glib2.0 (2.47.3-1) experimental; urgency=medium
+
+  * New upstream release
+    + New API: hardware-assisted helpers for overflow-checked integer math.
+    + Fixes: Invalid free in g_local_file_trash() (LP: #1512826)
+  * d/p/{Doc-copy-included-example-files.patch,
+    Doc-Fix-missing-glibconfig.h-when-builddir-srcdir.patch,
+    Build-gdbus-example-objectmanager-server-again.patch}: Remove - in this
+    upstream release.
+
+ -- Iain Lane <laney@debian.org>  Wed, 25 Nov 2015 17:59:33 +0000
+
+glib2.0 (2.47.1-1) experimental; urgency=medium
+
+  * New upstream release.
+    + The Unicode support has been updated to version 8.0 of the Unicode standard
+    + GDesktopAppInfo no longer sets the DISPLAY environment variable when
+      launching apps. This is now done in the GAppLaunchContext
+      implementations when appropriate.
+  * debian/watch: Look for development versions too.
+  * debian/patches/90_gio-modules-multiarch-compat.patch: Refresh to apply on
+    this version.
+  * debian/patches/0001-GDateTime-test-fix-occasional-failures.patch: Drop,
+    upstream in this release.
+  * debian/libglib2.0-0.symbols: Update with new symbols for this release.
+
+ -- Iain Lane <laney@debian.org>  Wed, 04 Nov 2015 17:28:23 +0000
 
 glib2.0 (2.46.2-3) unstable; urgency=medium
 

--- a/debian/libglib2.0-0-dbg.install.in
+++ b/debian/libglib2.0-0-dbg.install.in
@@ -1,3 +1,2 @@
-usr/share/gdb/auto-load/libglib-2.0.so.*-gdb.py usr/share/gdb/auto-load/lib/${DEB_HOST_MULTIARCH}
-usr/share/gdb/auto-load/libgobject-2.0.so.*-gdb.py usr/share/gdb/auto-load/usr/lib/${DEB_HOST_MULTIARCH}
+usr/share/gdb
 usr/share/glib-2.0/gdb

--- a/debian/libglib2.0-0.symbols
+++ b/debian/libglib2.0-0.symbols
@@ -269,6 +269,12 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_data_output_stream_set_byte_order@Base 2.16.0
  g_data_stream_byte_order_get_type@Base 2.16.0
  g_data_stream_newline_type_get_type@Base 2.16.0
+ g_datagram_based_condition_check@Base 2.47.1
+ g_datagram_based_condition_wait@Base 2.47.1
+ g_datagram_based_create_source@Base 2.47.1
+ g_datagram_based_get_type@Base 2.47.1
+ g_datagram_based_receive_messages@Base 2.47.1
+ g_datagram_based_send_messages@Base 2.47.1
  g_dbus_action_group_get@Base 2.31.8
  g_dbus_action_group_get_type@Base 2.31.8
  g_dbus_address_escape_value@Base 2.35.8
@@ -611,6 +617,38 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_drive_start_stop_type_get_type@Base 2.22.0
  g_drive_stop@Base 2.22.0
  g_drive_stop_finish@Base 2.22.0
+ g_dtls_client_connection_get_accepted_cas@Base 2.47.5
+ g_dtls_client_connection_get_server_identity@Base 2.47.5
+ g_dtls_client_connection_get_type@Base 2.47.5
+ g_dtls_client_connection_get_validation_flags@Base 2.47.5
+ g_dtls_client_connection_new@Base 2.47.5
+ g_dtls_client_connection_set_server_identity@Base 2.47.5
+ g_dtls_client_connection_set_validation_flags@Base 2.47.5
+ g_dtls_connection_close@Base 2.47.5
+ g_dtls_connection_close_async@Base 2.47.5
+ g_dtls_connection_close_finish@Base 2.47.5
+ g_dtls_connection_emit_accept_certificate@Base 2.47.5
+ g_dtls_connection_get_certificate@Base 2.47.5
+ g_dtls_connection_get_database@Base 2.47.5
+ g_dtls_connection_get_interaction@Base 2.47.5
+ g_dtls_connection_get_peer_certificate@Base 2.47.5
+ g_dtls_connection_get_peer_certificate_errors@Base 2.47.5
+ g_dtls_connection_get_rehandshake_mode@Base 2.47.5
+ g_dtls_connection_get_require_close_notify@Base 2.47.5
+ g_dtls_connection_get_type@Base 2.47.5
+ g_dtls_connection_handshake@Base 2.47.5
+ g_dtls_connection_handshake_async@Base 2.47.5
+ g_dtls_connection_handshake_finish@Base 2.47.5
+ g_dtls_connection_set_certificate@Base 2.47.5
+ g_dtls_connection_set_database@Base 2.47.5
+ g_dtls_connection_set_interaction@Base 2.47.5
+ g_dtls_connection_set_rehandshake_mode@Base 2.47.5
+ g_dtls_connection_set_require_close_notify@Base 2.47.5
+ g_dtls_connection_shutdown@Base 2.47.5
+ g_dtls_connection_shutdown_async@Base 2.47.5
+ g_dtls_connection_shutdown_finish@Base 2.47.5
+ g_dtls_server_connection_get_type@Base 2.47.5
+ g_dtls_server_connection_new@Base 2.47.5
  g_emblem_get_icon@Base 2.18.0
  g_emblem_get_origin@Base 2.18.0
  g_emblem_get_type@Base 2.18.0
@@ -1494,6 +1532,7 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_socket_connectable_enumerate@Base 2.22.0
  g_socket_connectable_get_type@Base 2.22.0
  g_socket_connectable_proxy_enumerate@Base 2.26.0
+ g_socket_connectable_to_string@Base 2.47.1
  g_socket_connection_connect@Base 2.31.8
  g_socket_connection_connect_async@Base 2.31.8
  g_socket_connection_connect_finish@Base 2.31.8
@@ -1558,6 +1597,7 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_socket_receive@Base 2.22.0
  g_socket_receive_from@Base 2.22.0
  g_socket_receive_message@Base 2.22.0
+ g_socket_receive_messages@Base 2.47.1
  g_socket_receive_with_blocking@Base 2.26.0
  g_socket_send@Base 2.22.0
  g_socket_send_message@Base 2.22.0
@@ -1702,9 +1742,12 @@ libgio-2.0.so.0 libglib2.0-0 #MINVER#
  g_tls_backend_get_client_connection_type@Base 2.28.0
  g_tls_backend_get_default@Base 2.28.0
  g_tls_backend_get_default_database@Base 2.30.0
+ g_tls_backend_get_dtls_client_connection_type@Base 2.47.5
+ g_tls_backend_get_dtls_server_connection_type@Base 2.47.5
  g_tls_backend_get_file_database_type@Base 2.30.0
  g_tls_backend_get_server_connection_type@Base 2.28.0
  g_tls_backend_get_type@Base 2.28.0
+ g_tls_backend_supports_dtls@Base 2.47.5
  g_tls_backend_supports_tls@Base 2.28.0
  g_tls_certificate_flags_get_type@Base 2.28.0
  g_tls_certificate_get_issuer@Base 2.28.0
@@ -2905,6 +2948,7 @@ libglib-2.0.so.0 libglib2.0-0 #MINVER#
  g_sequence_insert_before@Base 2.14.0
  g_sequence_insert_sorted@Base 2.14.0
  g_sequence_insert_sorted_iter@Base 2.14.0
+ g_sequence_is_empty@Base 2.47.1
  g_sequence_iter_compare@Base 2.14.0
  g_sequence_iter_get_position@Base 2.14.0
  g_sequence_iter_get_sequence@Base 2.14.0

--- a/debian/rules
+++ b/debian/rules
@@ -52,7 +52,7 @@ DEB_DH_INSTALL_ARGS_$(REFDBG_PKG) += --sourcedir=debian/install/refdbg
 
 DEB_DH_MAKESHLIBS_ARGS_$(SHARED_PKG) += -V --add-udeb=$(UDEB_PKG) -- -c4
 DEB_DH_MAKESHLIBS_ARGS_$(REFDBG_PKG) = --no-act
-DEB_DH_STRIP_ARGS_$(REFDBG_PKG) = --no-act
+DEB_DH_STRIP_ARGS_$(REFDBG_PKG) = --no-act --no-ddebs
 # Don't put the symbols in the -dbg package
 DEB_DH_STRIP_ARGS_$(UDEB_PKG) =
 

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
 version=3
-http://ftp.gnome.org/pub/GNOME/sources/glib/([\d\.]+[02468])/ \
+https://download.gnome.org/sources/glib/([\d\.]+)/ \
 	glib-(.*)\.tar\.xz


### PR DESCRIPTION
All the packaging changes are taken from Debian Sid, except we remove all
the distro patches here and commit them to our master branch.

https://phabricator.endlessm.com/T11430
