### PR TITLE
vfs: Fudge availability macros

### DIFF
--- a/gio/gvfs.h
+++ b/gio/gvfs.h
@@ -149,7 +149,7 @@ GVfs *                g_vfs_get_default               (void);
 GLIB_AVAILABLE_IN_ALL
 GVfs *                g_vfs_get_local                 (void);
 
-GLIB_AVAILABLE_IN_2_50
+GLIB_AVAILABLE_IN_2_48
 gboolean              g_vfs_register_uri_scheme       (GVfs               *vfs,
                                                        const char         *scheme,
                                                        GVfsFileLookupFunc  uri_func,
@@ -158,7 +158,7 @@ gboolean              g_vfs_register_uri_scheme       (GVfs               *vfs,
                                                        GVfsFileLookupFunc  parse_name_func,
                                                        gpointer            parse_name_data,
                                                        GDestroyNotify      parse_name_destroy);
-GLIB_AVAILABLE_IN_2_50
+GLIB_AVAILABLE_IN_2_48
 gboolean              g_vfs_unregister_uri_scheme     (GVfs               *vfs,
                                                        const char         *scheme);
 


### PR DESCRIPTION
We're backporting these functions to our version of 2.48, and with the
availability macros set to 2.50 they won't get introspected.

This patch can be dropped when we upgrade to 2.50 proper.

https://phabricator.endlessm.com/T11269
