### PR TITLE
Fix building on newer gcc version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3328,7 +3328,7 @@ AC_ARG_ENABLE(compile-warnings,
 			      enable_compile_warnings=yes)
 AS_IF([test "x$enable_compile_warnings" = xyes], [
   CC_CHECK_FLAGS_APPEND([GLIB_WARN_CFLAGS], [CFLAGS], [\
-   -Wall -Wstrict-prototypes -Werror=declaration-after-statement \
+   -Wall -Wno-format-y2k -Wstrict-prototypes -Werror=declaration-after-statement \
    -Werror=missing-prototypes -Werror=implicit-function-declaration \
    -Werror=pointer-arith -Werror=init-self -Werror=format-security \
    -Werror=format=2 -Werror=missing-include-dirs])


### PR DESCRIPTION
Newer GCC versions enable -Wformat-y2k and as we build with -Werror this becomes tragically fatal, there is a discution on bugzilla: https://bugzilla.gnome.org/show_bug.cgi?id=764575 about this.

This patch does _not_ implement the merged fix (a set of ugly pragmas) but instead Colin Walter's proposal to add -Wno-format-y2k

Signed-off-by: Niv Sardi xaiki@evilgiggle.com
