### PR TITLE
gappinfo: Use the real URI from the documents portal for native files

### DIFF
--- a/gio/gappinfo.c
+++ b/gio/gappinfo.c
@@ -828,7 +828,7 @@ launch_default_with_portal_async (const char          *uri,
 
   g_dbus_message_set_body (message, g_variant_new ("(ss@a{sv})",
                                                    parent_window ? parent_window : "",
-                                                   uri,
+                                                   real_uri,
                                                    g_variant_builder_end (&opt_builder)));
 
   /* FIXME: This should not be needed, but there seems to be a bug somewhere


### PR DESCRIPTION
We broke thing by mistake while rebasing against GLib 2.50 in the past,
rendering the documents portal useless when used from GLib, like it's
the case when using g_app_info_launch_default_for_uri. See the offending
commit at https://github.com/endlessm/glib/pull/23/commits/f0e52530.

https://phabricator.endlessm.com/T12978