### PR TITLE
Update to 2.54.2 from Debian Sid

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,71 @@
-glib2.0 (2.53.6-0) unstable; urgency=medium
+glib2.0 (2.54.2-1endless0) unstable; urgency=medium
+
+  * Rebase Endless changes on latest Debian Sid package
+    - Only difference from upstream is the
+      g_get_user_special_dir_for_desktop_id() symbol
+    - Apply all 13 patches from debian/patches/ to git and drop them from
+      the Debian directory
+    - Some of these patches were not applied in the previous Endless GLib
+      package, but I can see no reason why we had diverged from Debian;
+      they’re all unconditionally applied now
+    - Rebase the code on upstream/glib-2-54, including some patches which will
+      eventually be released in 2.54.3
+
+ -- Philip Withnall <withnall@endlessm.com>  Mon, 27 Nov 2017 08:56:00 +0000
+
+glib2.0 (2.54.2-1) unstable; urgency=medium
+
+  [ Jeremy Bicha ]
+  * New upstream release
+
+  [ Didier Roche ]
+  * debian/patches/01_gettext-desktopfiles.patch:
+    - fix untranslated desktop action names when using gettext
+      (Closes: #877761)
+
+  [ Simon McVittie ]
+  * Skip gtk-doc documentation unless we are building libglib2.0-doc,
+    fixing cross-builds (Closes: #870346)
+    - Note that gtk-doc-tools is still in Build-Depends, not
+      Build-Depends-Indep, because we need it for autoreconf
+  * Explicitly disable documentation for the udeb build
+  * Skip build-time tests for Arch:all builds - testing once per
+    architecture is sufficient
+  * Remove unused lintian override for an example file that is no
+    longer installed
+
+ -- Jeremy Bicha <jbicha@debian.org>  Fri, 27 Oct 2017 21:16:41 -0400
+
+glib2.0 (2.54.1-1) unstable; urgency=medium
+
+  [ Jeremy Bicha ]
+  * New upstream release
+  * Bump Standards-Version to 4.1.1
+
+  [ Michael Biebl ]
+  * Drop uploaders.mk include as it breaks the clean target.
+    Updating the Uploaders list is already handled by the gnome dh addon.
+
+ -- Jeremy Bicha <jbicha@debian.org>  Mon, 02 Oct 2017 12:13:25 -0400
+
+glib2.0 (2.54.0-1) unstable; urgency=medium
+
+  * New upstream stable release.
+
+ -- Emilio Pozuelo Monfort <pochu@debian.org>  Mon, 11 Sep 2017 19:11:00 +0200
+
+glib2.0 (2.53.7-1) unstable; urgency=medium
+
+  * New upstream release.
+  * debian/patches/81-skip-monitor-test-on-non-linux.patch:
+    + Refreshed.
+  * debian/control.in: drop automake and autotools-dev build dependencies,
+    dh-autoreconf does that for us.
+  * Bump Standards-Version to 4.1.0; no changes needed.
+
+ -- Emilio Pozuelo Monfort <pochu@debian.org>  Sat, 09 Sep 2017 15:11:02 +0200
+
+glib2.0 (2.53.6-1) unstable; urgency=medium
 
   * New upstream release.
   * git_glib-mkenums-utf8.patch, git_glib-mkenums-flags.patch: Drop, now

--- a/debian/control
+++ b/debian/control
@@ -6,18 +6,16 @@ Source: glib2.0
 Section: libs
 Priority: optional
 Maintainer: Debian GNOME Maintainers <pkg-gnome-maintainers@lists.alioth.debian.org>
-Uploaders: Iain Lane <laney@debian.org>, Matthias Klumpp <mak@debian.org>
-Build-Depends: debhelper (>= 10~),
+Uploaders: Emilio Pozuelo Monfort <pochu@debian.org>, Iain Lane <laney@debian.org>, Jeremy Bicha <jbicha@debian.org>, Matthias Klumpp <mak@debian.org>
+Build-Depends: debhelper (>= 10.3~),
                dh-exec,
                dh-python,
                pkg-config (>= 0.16.0),
                gettext,
-               automake,
-               autotools-dev,
                gnome-pkg-tools (>= 0.11),
                dpkg-dev (>= 1.17.14),
                libelf-dev (>= 0.142),
-               libmount-dev [linux-any],
+               libmount-dev (>= 2.28) [linux-any],
                libpcre3-dev (>= 1:8.35),
                gtk-doc-tools (>= 1.20),
                libselinux1-dev [linux-any],
@@ -37,7 +35,7 @@ Build-Depends: debhelper (>= 10~),
                docbook-xml,
                docbook-xsl,
                libffi-dev (>= 3.0.0)
-Standards-Version: 3.9.8
+Standards-Version: 4.1.1
 Homepage: http://www.gtk.org/
 Vcs-Browser: https://anonscm.debian.org/viewvc/pkg-gnome/desktop/unstable/glib2.0/
 Vcs-Svn: svn://anonscm.debian.org/pkg-gnome/desktop/unstable/glib2.0/

--- a/debian/control.in
+++ b/debian/control.in
@@ -3,13 +3,11 @@ Section: libs
 Priority: optional
 Maintainer: Debian GNOME Maintainers <pkg-gnome-maintainers@lists.alioth.debian.org>
 Uploaders: @GNOME_TEAM@
-Build-Depends: debhelper (>= 10~),
+Build-Depends: debhelper (>= 10.3~),
                dh-exec,
                dh-python,
                pkg-config (>= 0.16.0),
                gettext,
-               automake,
-               autotools-dev,
                gnome-pkg-tools (>= 0.11),
                dpkg-dev (>= 1.17.14),
                libelf-dev (>= 0.142),
@@ -33,7 +31,7 @@ Build-Depends: debhelper (>= 10~),
                docbook-xml,
                docbook-xsl,
                libffi-dev (>= 3.0.0)
-Standards-Version: 3.9.8
+Standards-Version: 4.1.1
 Homepage: http://www.gtk.org/
 Vcs-Browser: https://anonscm.debian.org/viewvc/pkg-gnome/desktop/unstable/glib2.0/
 Vcs-Svn: svn://anonscm.debian.org/pkg-gnome/desktop/unstable/glib2.0/

--- a/debian/libglib2.0-doc.lintian-overrides
+++ b/debian/libglib2.0-doc.lintian-overrides
@@ -1,2 +1,0 @@
-# This is deliberate, it shouldn't appear in devhelp
-libglib2.0-doc: package-contains-devhelp-file-without-symlink usr/share/doc/libglib2.0-doc/gdbus-object-manager-example/gdbus-object-manager-example.devhelp2.gz

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,5 @@
 #!/usr/bin/make -f
 
-include /usr/share/gnome-pkg-tools/1/rules/uploaders.mk
 include /usr/share/gnome-pkg-tools/1/rules/gnome-get-source.mk
 
 GNOME_MODULE := glib
@@ -78,12 +77,18 @@ unexport XDG_DATA_DIRS
 export DBUS_SESSION_BUS_ADDRESS=this-should-not-be-used-and-will-fail:
 
 ifeq ($(DEB_HOST_ARCH_OS), linux)
-override_dh_auto_test:
-	dh_auto_test -- --builddirectory=debian/build/deb -k check -j1
+override_dh_auto_test-arch:
+	# Remove LD_PRELOAD so we don't run with fakeroot, which makes dbus-related tests fail
+	env -u LD_PRELOAD dh_auto_test --builddirectory=debian/build/deb -- -k check -j1
 else
-override_dh_auto_test:
-	dh_auto_test -- --builddirectory=debian/build/deb -k check -j1 || true
+override_dh_auto_test-arch:
+	env -u LD_PRELOAD dh_auto_test --builddirectory=debian/build/deb -- -k check -j1 || true
 endif
+
+# Skip build-time tests if all we are building is documentation; running
+# them once per architecture is plenty
+override_dh_auto_test-indep:
+	@:
 
 # The tests assume this directory exists and is writable
 export XDG_RUNTIME_DIR=$(CURDIR)/debian/tmp-xdg-runtime-dir
@@ -98,18 +103,17 @@ DEB_CONFIGURE_EXTRA_FLAGS := \
 			--with-python=/usr/bin/python3 \
 			--with-pcre=system
 
-ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
-  DEB_CONFIGURE_EXTRA_FLAGS += \
-			--disable-modular-tests \
-			--disable-gtk-doc
-endif
-
 DEB_CONFIGURE_FLAGS_deb := \
-			--enable-gtk-doc \
 			--enable-static \
 			--enable-installed-tests \
 			--enable-always-build-tests \
 			--enable-debug=minimum
+
+ifneq ($(filter libglib2.0-doc,$(binaries)),)
+DEB_CONFIGURE_FLAGS_deb += --enable-gtk-doc
+else
+DEB_CONFIGURE_FLAGS_deb += --disable-gtk-doc
+endif
 
 # libmount is available on linux only
 ifeq ($(DEB_HOST_ARCH_OS), linux)
@@ -123,7 +127,8 @@ endif
 
 DEB_CONFIGURE_FLAGS_udeb := \
 			--disable-selinux \
-			--disable-libmount
+			--disable-libmount \
+			--disable-gtk-doc
 
 override_dh_auto_build:
 	mkdir -p debian/tmp-xdg-runtime-dir
@@ -139,7 +144,7 @@ override_dh_auto_install:
 		    debian/libglib2.0-0.$$script.in \
 		    > debian/libglib2.0-0.$$script ; \
 	done
-	dh_auto_install -plibglib2.0-tests --sourcedir=debian/build/deb -X.la
+	dh_auto_install -plibglib2.0-tests --sourcedir=debian/build/deb
 ifneq ($(filter %-udeb,$(binaries)),)
 	dh_auto_install -plibglib2.0-udeb --builddirectory=debian/build/udeb --destdir=debian/install/udeb
 endif
@@ -168,10 +173,14 @@ ifneq ($(filter %-udeb,$(binaries)),)
 	rm -fr debian/install/udeb/usr/share/glib-2.0/gdb
 	rm -fr debian/install/udeb/usr/share/glib-2.0/valgrind
 	rm -fr debian/install/udeb/usr/share/man
-	dh_install -plibglib2.0-udeb --sourcedir=debian/install/udeb --list-missing
+	dh_install -plibglib2.0-udeb --sourcedir=debian/install/udeb
 endif
 	# Put the gdb script in .../gdb/auto-load/lib, as we install libglib*.so in there
 	mkdir -p debian/install/deb/usr/share/gdb/auto-load/lib/${DEB_HOST_MULTIARCH}/
 	mv debian/install/deb/usr/share/gdb/auto-load/usr/lib/${DEB_HOST_MULTIARCH}/libglib*so*py \
 		debian/install/deb/usr/share/gdb/auto-load/lib/${DEB_HOST_MULTIARCH}/
-	dh_install --remaining-packages --sourcedir=debian/install/deb --list-missing
+	dh_install --remaining-packages --sourcedir=debian/install/deb
+
+override_dh_missing:
+	dh_missing --sourcedir=debian/install/udeb --fail-missing
+	dh_missing --sourcedir=debian/install/deb --fail-missing


### PR DESCRIPTION
  * Rebase Endless changes on latest Debian Sid package
    - Only difference from upstream is the
      g_get_user_special_dir_for_desktop_id() symbol
    - Apply all 13 patches from debian/patches/ to git and drop them from
      the Debian directory
    - Some of these patches were not applied in the previous Endless GLib
      package, but I can see no reason why we had diverged from Debian;
      they’re all unconditionally applied now

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20056

---

Code changes are in https://github.com/endlessm/glib/pull/31.