### PR TITLE
Backport -fno-strict-aliasing changes from upstream 2.55.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2632,6 +2632,14 @@ AS_IF([ test "x$use_gcov" = "xyes"], [
   LDFLAGS="$LDFLAGS -lgcov"
 ])
 
+dnl *******************************
+dnl *** Disable strict aliasing ***
+dnl *******************************
+dnl See https://bugzilla.gnome.org/show_bug.cgi?id=791622
+AS_IF([test "${GCC}" = "yes"],[
+  CFLAGS="$CFLAGS -fno-strict-aliasing"
+])
+
 dnl ******************************
 dnl *** output the whole stuff ***
 dnl ******************************

--- a/docs/reference/glib/building.xml
+++ b/docs/reference/glib/building.xml
@@ -42,6 +42,13 @@
       the standard options.
     </para>
     <para>
+      GLib is compiled with
+      <ulink url="https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-fstrict-aliasing">strict aliasing</ulink>
+      disabled. It is strongly recommended that this is not re-enabled by
+      overriding the compiler flags, as GLib has not been tested with strict
+      aliasing and cannot be guaranteed to work.
+    </para>
+    <para>
       The GTK+ documentation contains
       <ulink url="../gtk/gtk-building.html">further details</ulink>
       about the build process and ways to influence it.

--- a/glib/gmem.h
+++ b/glib/gmem.h
@@ -113,16 +113,17 @@ gpointer g_try_realloc_n  (gpointer	 mem,
 #define g_clear_pointer(pp, destroy) \
   G_STMT_START {                                                               \
     G_STATIC_ASSERT (sizeof *(pp) == sizeof (gpointer));                       \
-    /* Only one access, please */                                              \
-    gpointer *_pp = (gpointer *) (pp);                                         \
+    /* Only one access, please; work around type aliasing */                   \
+    union { char *in; gpointer *out; } _pp;                                    \
     gpointer _p;                                                               \
     /* This assignment is needed to avoid a gcc warning */                     \
     GDestroyNotify _destroy = (GDestroyNotify) (destroy);                      \
                                                                                \
-    _p = *_pp;                                                                 \
+    _pp.in = (char *) (pp);                                                    \
+    _p = *_pp.out;                                                             \
     if (_p) 								       \
       { 								       \
-        *_pp = NULL;							       \
+        *_pp.out = NULL;                                                       \
         _destroy (_p);                                                         \
       }                                                                        \
   } G_STMT_END

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,10 @@ glib_pkgconfigreldir = join_paths(glib_libdir, 'pkgconfig')
 
 add_project_arguments('-D_GNU_SOURCE', language: 'c')
 
+# Disable strict aliasing;
+# see https://bugzilla.gnome.org/show_bug.cgi?id=791622
+add_project_arguments('-fno-strict-aliasing', language: 'c')
+
 ########################
 # Configuration begins #
 ########################


### PR DESCRIPTION
Backports from https://bugzilla.gnome.org/show_bug.cgi?id=791622, mostly to shut up the warnings about `g_clear_pointer()` I’m getting in Mogwai.

All these patches are in the upstream 2.55.1 release, and have been used to build GNOME for a month.