### PR TITLE
debian: Add g_log_structured_standard() to symbols file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+glib2.0 (2.54.2-1endless1) unstable; urgency=medium
+
+  * Backport structured logging changes to enable -Wformat warnings again
+    https://bugzilla.gnome.org/show_bug.cgi?id=793074
+
+ -- Philip Withnall <withnall@endlessm.com>  Fri, 09 Feb 2018 16:38:00 +0000
+
 glib2.0 (2.54.2-1endless0) unstable; urgency=medium
 
   * Rebase Endless changes on latest Debian Sid package

--- a/debian/libglib2.0-0.symbols
+++ b/debian/libglib2.0-0.symbols
@@ -2599,6 +2599,7 @@ libglib-2.0.so.0 libglib2.0-0 #MINVER#
  g_log_set_writer_func@Base 2.49.3
  g_log_structured@Base 2.49.3
  g_log_structured_array@Base 2.49.3
+ g_log_structured_standard@Base 2.54.2-1endless1
  g_log_variant@Base 2.49.7
  g_log_writer_default@Base 2.49.3
  g_log_writer_format_fields@Base 2.49.3


### PR DESCRIPTION
This is needed by commit b6cf1e0b8cb96f173b5347e42990a79b5e025b21 on
master, which backports the following upstream change to Endless:

https://bugzilla.gnome.org/show_bug.cgi?id=793074

This bumps our version to 2.54.2-1endless1 so we have a version to list
against in the symbol file.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

Forgot about doing this when doing PR #35, which resulted in [this failure on OBS](https://obs-master.endlessm-sf.com/package/live_build_log?arch=x86_64&package=glib2.0&project=eos%3Amaster%3Aendless&repository=endless). Oops.