### PR TITLE
gunixmounts: Allow root to display mounts under /run/media/$username

### DIFF
--- a/gio/gunixmounts.c
+++ b/gio/gunixmounts.c
@@ -2588,18 +2588,29 @@ g_unix_mount_guess_should_display (GUnixMountEntry *mount_entry)
   mount_path = mount_entry->mount_path;
   if (mount_path != NULL)
     {
+      uid_t uid = getuid ();
       gboolean is_in_runtime_dir = FALSE;
+
       /* Hide mounts within a dot path, suppose it was a purpose to hide this mount */
       if (g_strstr_len (mount_path, -1, "/.") != NULL)
         return FALSE;
 
-      /* Check /run/media/$USER/ */
-      user_name = g_get_user_name ();
-      user_name_len = strlen (user_name);
-      if (strncmp (mount_path, "/run/media/", sizeof ("/run/media/") - 1) == 0 &&
-          strncmp (mount_path + sizeof ("/run/media/") - 1, user_name, user_name_len) == 0 &&
-          mount_path[sizeof ("/run/media/") - 1 + user_name_len] == '/')
-        is_in_runtime_dir = TRUE;
+      /* Check /run/media/$USER/. If running as root, display any mounts below
+       * /run/media/. */
+      if (uid == 0)
+        {
+          if (strncmp (mount_path, "/run/media/", strlen ("/run/media/")) == 0)
+            is_in_runtime_dir = TRUE;
+        }
+      else
+        {
+          user_name = g_get_user_name ();
+          user_name_len = strlen (user_name);
+          if (strncmp (mount_path, "/run/media/", strlen ("/run/media/")) == 0 &&
+              strncmp (mount_path + strlen ("/run/media/"), user_name, user_name_len) == 0 &&
+              mount_path[strlen ("/run/media/") + user_name_len] == '/')
+            is_in_runtime_dir = TRUE;
+        }
 
       if (is_in_runtime_dir || g_str_has_prefix (mount_path, "/media/"))
         {


### PR DESCRIPTION
Normally, the list of mounts is filtered to exclude mounts in
/run/media/$username where $username is not the current user. However,
root can access all the mounts under /run/media/, regardless of the
username — so there’s no point in filtering out those mounts.

In some cases, filtering them out is harmful. In the case of a system
service which uses GVolumeMonitor, for example, filtering them out means
the service cannot see automounted USB sticks belonging to user
sessions.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://bugzilla.gnome.org/show_bug.cgi?id=793994