### PR TITLE
debian: Add new utility functions to symbols file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+glib2.0 (2.54.2-1endless2) unstable; urgency=medium
+
+  * Backport new utility functions:
+    - g_clear_handle_id(): https://bugzilla.gnome.org/show_bug.cgi?id=788489
+    - g_date_time_new_from_iso8601():
+      https://bugzilla.gnome.org/show_bug.cgi?id=753459
+
+ -- Philip Withnall <withnall@endlessm.com>  Fri, 09 Mar 2018 15:05:00 +0000
+
 glib2.0 (2.54.2-1endless1) unstable; urgency=medium
 
   * Backport structured logging changes to enable -Wformat warnings again

--- a/debian/libglib2.0-0.symbols
+++ b/debian/libglib2.0-0.symbols
@@ -2173,6 +2173,7 @@ libglib-2.0.so.0 libglib2.0-0 #MINVER#
  g_child_watch_source_new@Base 2.12.0
  g_chmod@Base 2.12.0
  g_clear_error@Base 2.12.0
+ g_clear_handle_id@Base 2.54.2-1endless2
  g_clear_pointer@Base 2.33.14
  g_close@Base 2.35.8
  g_completion_add_items@Base 2.12.0
@@ -2291,6 +2292,7 @@ libglib-2.0.so.0 libglib2.0-0 #MINVER#
  g_date_time_hash@Base 2.26.0
  g_date_time_is_daylight_savings@Base 2.26.0
  g_date_time_new@Base 2.26.0
+ g_date_time_new_from_iso8601@Base 2.54.2-1endless2
  g_date_time_new_from_timeval_local@Base 2.26.0
  g_date_time_new_from_timeval_utc@Base 2.26.0
  g_date_time_new_from_unix_local@Base 2.26.0


### PR DESCRIPTION
g_clear_handle_id() and g_date_time_new_from_iso8601() have been
backported from master, so need to be added to the symbols file.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T21497

---

Debian changes to accompany #39.