### PR TITLE
debian: Add new GDateTime/GTimeZone methods to symbols file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+glib2.0 (2.54.2-1endless3) unstable; urgency=medium
+
+  * Backport new GDateTime and GTimeZone methods:
+    - g_date_time_get_timezone()
+    - g_time_zone_get_identifier()
+    - See https://bugzilla.gnome.org/show_bug.cgi?id=795165
+
+ -- Philip Withnall <withnall@endlessm.com>  Thu, 12 Apr 2018 14:23:00 +0100
+
 glib2.0 (2.54.2-1endless2) unstable; urgency=medium
 
   * Backport new utility functions:

--- a/debian/libglib2.0-0.symbols
+++ b/debian/libglib2.0-0.symbols
@@ -2283,6 +2283,7 @@ libglib-2.0.so.0 libglib2.0-0 #MINVER#
  g_date_time_get_month@Base 2.26.0
  g_date_time_get_second@Base 2.26.0
  g_date_time_get_seconds@Base 2.26.0
+ g_date_time_get_timezone@Base 2.54.2-1endless3
  g_date_time_get_timezone_abbreviation@Base 2.26.0
  g_date_time_get_utc_offset@Base 2.26.0
  g_date_time_get_week_numbering_year@Base 2.28.0
@@ -3301,6 +3302,7 @@ libglib-2.0.so.0 libglib2.0-0 #MINVER#
  g_time_zone_adjust_time@Base 2.28.0
  g_time_zone_find_interval@Base 2.28.0
  g_time_zone_get_abbreviation@Base 2.28.0
+ g_time_zone_get_identifier@Base 2.54.2-1endless3
  g_time_zone_get_offset@Base 2.28.0
  g_time_zone_is_dst@Base 2.28.0
  g_time_zone_new@Base 2.26.0


### PR DESCRIPTION
g_date_time_get_timezone() and g_time_zone_get_identifier() were added
upstream in https://bugzilla.gnome.org/show_bug.cgi?id=795165, and we
need to use them in Mogwai.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T21500

---

See #41 for the main changes.