### PR TITLE
debian: Add new internal GVariant symbols to symbols file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+glib2.0 (2.54.2-1endless5) eos; urgency=medium
+
+  * Backport GVariant/GDBus/GMarkup fuzz-testing fixes
+    This fixes several remotely exploitable heap handling problems.
+    https://phabricator.endlessm.com/T24339
+
+ -- Philip Withnall <withnall@endlessm.com>  Mon, 05 Nov 2018 13:07:00 +0000
+
 glib2.0 (2.54.2-1endless4) eos; urgency=medium
 
   * Backport gspawn/posix_spawn improvements

--- a/debian/libglib2.0-0.symbols
+++ b/debian/libglib2.0-0.symbols
@@ -3591,6 +3591,7 @@ libglib-2.0.so.0 libglib2.0-0 #MINVER#
  g_variant_type_info_member_info@Base 2.24.0
  g_variant_type_info_n_members@Base 2.24.0
  g_variant_type_info_query@Base 2.24.0
+ g_variant_type_info_query_depth@Base 2.54.2-1endless5
  g_variant_type_info_query_element@Base 2.24.0
  g_variant_type_info_ref@Base 2.24.0
  g_variant_type_info_unref@Base 2.24.0
@@ -3612,6 +3613,7 @@ libglib-2.0.so.0 libglib2.0-0 #MINVER#
  g_variant_type_new_tuple@Base 2.24.0
  g_variant_type_next@Base 2.24.0
  g_variant_type_peek_string@Base 2.24.0
+ g_variant_type_string_get_depth_@Base 2.54.2-1endless5
  g_variant_type_string_is_valid@Base 2.24.0
  g_variant_type_string_scan@Base 2.24.0
  g_variant_type_value@Base 2.24.0


### PR DESCRIPTION
These symbols are all internal API, but do need to be exported from the
.so file.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24339