### PR TITLE
g_clear_handle_id: don't accept NULL clear_func

### DIFF
--- a/glib/gmain.c
+++ b/glib/gmain.c
@@ -2442,8 +2442,7 @@ g_clear_handle_id (guint            *tag_ptr,
   if (_handle_id > 0)
     {
       *tag_ptr = 0;
-      if (clear_func != NULL)
-        clear_func (_handle_id);
+      clear_func (_handle_id);
     }
 }
 

--- a/glib/gmain.h
+++ b/glib/gmain.h
@@ -590,8 +590,7 @@ void    g_clear_handle_id (guint           *tag_ptr,
     if (_handle_id > 0)                                    \
       {                                                    \
         *_tag_ptr = 0;                                     \
-        if (clear_func != NULL)                            \
-          clear_func (_handle_id);                         \
+        clear_func (_handle_id);                           \
       }                                                    \
   } G_STMT_END
 


### PR DESCRIPTION
Backported from https://gitlab.gnome.org/GNOME/glib/merge_requests/55 because I'm tired of seeing this warning I fixed 5 months ago.

https://phabricator.endlessm.com/T24596