### PR TITLE
T25384 Fix flaky socket-service and gsocketclient-slow tests

### DIFF
--- a/gio/tests/meson.build
+++ b/gio/tests/meson.build
@@ -150,7 +150,6 @@ if host_machine.system() != 'windows'
       'installed_tests_env' : {
         'LD_PRELOAD': '@0@/slow-connect-preload.so'.format(installed_tests_execdir),
       },
-      'suite': ['flaky'],
     },
     'gschema-compile' : {'install' : false},
     'trash' : {},

--- a/gio/tests/meson.build
+++ b/gio/tests/meson.build
@@ -67,7 +67,7 @@ gio_tests = {
   'sleepy-stream' : {},
   'socket' : {},
   'socket-listener' : {},
-  'socket-service' : { 'suite': ['flaky'] },
+  'socket-service' : {},
   'srvtarget' : {},
   'task' : {},
   'vfs' : {},

--- a/gio/tests/meson.build
+++ b/gio/tests/meson.build
@@ -134,24 +134,24 @@ if host_machine.system() != 'windows'
     'unix-mounts' : {},
     'unix-streams' : {},
     'g-file-info-filesystem-readonly' : {},
-#    'gsocketclient-slow' : {
-#      'depends' : [
-#        shared_library('slow-connect-preload',
-#          'slow-connect-preload.c',
-#          name_prefix : '',
-#          dependencies: cc.find_library('dl'),
-#          install_dir : installed_tests_execdir,
-#          install: installed_tests_enabled,
-#        )
-#      ],
-#      'env' : {
-#        'LD_PRELOAD': '@0@/slow-connect-preload.so'.format(meson.current_build_dir())
-#      },
-#      'installed_tests_env' : {
-#        'LD_PRELOAD': '@0@/slow-connect-preload.so'.format(installed_tests_execdir),
-#      },
-#      'suite': ['flaky'],
-#    },
+    'gsocketclient-slow' : {
+      'depends' : [
+        shared_library('slow-connect-preload',
+          'slow-connect-preload.c',
+          name_prefix : '',
+          dependencies: cc.find_library('dl'),
+          install_dir : installed_tests_execdir,
+          install: installed_tests_enabled,
+        )
+      ],
+      'env' : {
+        'LD_PRELOAD': '@0@/slow-connect-preload.so'.format(meson.current_build_dir())
+      },
+      'installed_tests_env' : {
+        'LD_PRELOAD': '@0@/slow-connect-preload.so'.format(installed_tests_execdir),
+      },
+      'suite': ['flaky'],
+    },
     'gschema-compile' : {'install' : false},
     'trash' : {},
   }

--- a/gio/tests/socket-service.c
+++ b/gio/tests/socket-service.c
@@ -222,6 +222,11 @@ test_threaded_712570 (void)
     g_main_context_iteration (NULL, TRUE);
   while (G_OBJECT (service)->ref_count > 3);
 
+  /* Wait some more iterations, as #GTask results are deferred to the next
+   * #GMainContext iteration, and propagation of a #GTask result takes an
+   * additional ref on the source object. */
+  g_main_context_iteration (NULL, FALSE);
+
   /* Drop our ref, then unlock the mutex and wait for the service to be
    * finalized. (Without the fix for 712570 it would hang forever here.)
    */


### PR DESCRIPTION
This backports some upstream fixes which will be in the 2.60.0 release.

It should hopefully fix Jenkins periodically failing, which has snarfed up the OBS build at the moment.

https://phabricator.endlessm.com/T25384