### PR TITLE
Cherry-pick memory error fixes for g_test_dbus_down()

### DIFF
--- a/gio/gtestdbus.c
+++ b/gio/gtestdbus.c
@@ -84,8 +84,9 @@ _g_object_unref_and_wait_weak_notify (gpointer object)
 
   g_object_weak_ref (object, (GWeakNotify) g_main_loop_quit, data.loop);
 
-  /* Drop the ref in an idle callback, this is to make sure the mainloop
-   * is already running when weak notify happens */
+  /* Drop the strong ref held by the caller in an idle callback. This is to
+   * make sure the mainloop is already running when weak notify happens (when
+   * all other strong ref holders have dropped theirs). */
   g_idle_add (unref_on_idle, object);
 
   /* Make sure we don't block forever */

--- a/gio/gtestdbus.c
+++ b/gio/gtestdbus.c
@@ -67,15 +67,14 @@ on_weak_notify_timeout (gpointer user_data)
 }
 
 static gboolean
-dispose_on_idle (gpointer object)
+unref_on_idle (gpointer object)
 {
-  g_object_run_dispose (object);
   g_object_unref (object);
   return FALSE;
 }
 
 static gboolean
-_g_object_dispose_and_wait_weak_notify (gpointer object)
+_g_object_unref_and_wait_weak_notify (gpointer object)
 {
   WeakNotifyData data;
   guint timeout_id;
@@ -87,7 +86,7 @@ _g_object_dispose_and_wait_weak_notify (gpointer object)
 
   /* Drop the ref in an idle callback, this is to make sure the mainloop
    * is already running when weak notify happens */
-  g_idle_add (dispose_on_idle, object);
+  g_idle_add (unref_on_idle, object);
 
   /* Make sure we don't block forever */
   timeout_id = g_timeout_add (30 * 1000, on_weak_notify_timeout, &data);
@@ -820,7 +819,7 @@ g_test_dbus_down (GTestDBus *self)
     stop_daemon (self);
 
   if (connection != NULL)
-    _g_object_dispose_and_wait_weak_notify (connection);
+    _g_object_unref_and_wait_weak_notify (connection);
 
   g_test_dbus_unset ();
   _g_bus_forget_singleton (G_BUS_TYPE_SESSION);

--- a/gio/tests/gdbus-connection-loss.c
+++ b/gio/tests/gdbus-connection-loss.c
@@ -136,9 +136,10 @@ main (int   argc,
 
   ret = g_test_run();
 
+  g_object_unref (c);
+
   session_bus_down ();
 
-  g_object_unref (c);
   g_main_loop_unref (loop);
 
   return ret;

--- a/gio/tests/gdbus-names.c
+++ b/gio/tests/gdbus-names.c
@@ -472,9 +472,6 @@ test_bus_own_name (void)
   g_object_unref (c2);
 
   session_bus_down ();
-
-  /* See https://bugzilla.gnome.org/show_bug.cgi?id=711807 */
-  g_usleep (1000000);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
These are cherry-picks from upstream.

https://phabricator.endlessm.com/T25264