### PR TITLE
T27828 Fix file copy permissions

### DIFF
--- a/gio/gfile.c
+++ b/gio/gfile.c
@@ -3188,6 +3188,7 @@ file_copy_fallback (GFile                  *source,
   const char *target;
   char *attrs_to_read;
   gboolean do_set_attributes = FALSE;
+  GFileCreateFlags create_flags;
 
   /* need to know the file type */
   info = g_file_query_info (source,
@@ -3278,18 +3279,21 @@ file_copy_fallback (GFile                  *source,
    * If a future API like g_file_replace_with_info() is added, switch
    * this code to use that.
    */
+  create_flags = G_FILE_CREATE_PRIVATE;
+  if (flags & G_FILE_COPY_OVERWRITE)
+    create_flags |= G_FILE_CREATE_REPLACE_DESTINATION;
+
   if (G_IS_LOCAL_FILE (destination))
     {
       if (flags & G_FILE_COPY_OVERWRITE)
         out = (GOutputStream*)_g_local_file_output_stream_replace (_g_local_file_get_filename (G_LOCAL_FILE (destination)),
                                                                    FALSE, NULL,
                                                                    flags & G_FILE_COPY_BACKUP,
-                                                                   G_FILE_CREATE_REPLACE_DESTINATION |
-                                                                   G_FILE_CREATE_PRIVATE, info,
+                                                                   create_flags, info,
                                                                    cancellable, error);
       else
         out = (GOutputStream*)_g_local_file_output_stream_create (_g_local_file_get_filename (G_LOCAL_FILE (destination)),
-                                                                  FALSE, G_FILE_CREATE_PRIVATE, info,
+                                                                  FALSE, create_flags, info,
                                                                   cancellable, error);
     }
   else if (flags & G_FILE_COPY_OVERWRITE)
@@ -3297,13 +3301,12 @@ file_copy_fallback (GFile                  *source,
       out = (GOutputStream *)g_file_replace (destination,
                                              NULL,
                                              flags & G_FILE_COPY_BACKUP,
-                                             G_FILE_CREATE_REPLACE_DESTINATION |
-                                             G_FILE_CREATE_PRIVATE,
+                                             create_flags,
                                              cancellable, error);
     }
   else
     {
-      out = (GOutputStream *)g_file_create (destination, G_FILE_CREATE_PRIVATE, cancellable, error);
+      out = (GOutputStream *)g_file_create (destination, create_flags, cancellable, error);
     }
 
   if (!out)

--- a/gio/gfileinfo.c
+++ b/gio/gfileinfo.c
@@ -1822,7 +1822,7 @@ g_file_info_get_modification_date_time (GFileInfo *info)
   if (value_usec == NULL)
     return g_steal_pointer (&dt);
 
-  dt2 = g_date_time_add_seconds (dt, _g_file_attribute_value_get_uint32 (value_usec) / (gdouble) G_USEC_PER_SEC);
+  dt2 = g_date_time_add (dt, _g_file_attribute_value_get_uint32 (value_usec));
   g_date_time_unref (dt);
 
   return g_steal_pointer (&dt2);

--- a/glib/gvariant-core.c
+++ b/glib/gvariant-core.c
@@ -949,6 +949,12 @@ g_variant_get_data_as_bytes (GVariant *value)
   data = value->contents.serialised.data;
   size = value->size;
 
+  if (data == NULL)
+    {
+      g_assert (size == 0);
+      data = bytes_data;
+    }
+
   if (data == bytes_data && size == bytes_size)
     return g_bytes_ref (value->contents.serialised.bytes);
   else

--- a/glib/tests/gvariant.c
+++ b/glib/tests/gvariant.c
@@ -2304,6 +2304,46 @@ test_byteswaps (void)
 }
 
 static void
+test_serialiser_children (void)
+{
+  GBytes *data1, *data2;
+  GVariant *child1, *child2;
+  GVariantType *mv_type = g_variant_type_new_maybe (G_VARIANT_TYPE_VARIANT);
+  GVariant *variant, *child;
+
+  g_test_bug ("https://gitlab.gnome.org/GNOME/glib/issues/1865");
+  g_test_summary ("Test that getting a child variant before and after "
+                  "serialisation of the parent works");
+
+  /* Construct a variable sized array containing a child which serialises to a
+   * zero-length bytestring. */
+  child = g_variant_new_maybe (G_VARIANT_TYPE_VARIANT, NULL);
+  variant = g_variant_new_array (mv_type, &child, 1);
+
+  /* Get the child before serialising. */
+  child1 = g_variant_get_child_value (variant, 0);
+  data1 = g_variant_get_data_as_bytes (child1);
+
+  /* Serialise the parent variant. */
+  g_variant_get_data (variant);
+
+  /* Get the child again after serialising — this uses a different code path. */
+  child2 = g_variant_get_child_value (variant, 0);
+  data2 = g_variant_get_data_as_bytes (child2);
+
+  /* Check things are equal. */
+  g_assert_cmpvariant (child1, child2);
+  g_assert_true (g_bytes_equal (data1, data2));
+
+  g_variant_unref (child2);
+  g_variant_unref (child1);
+  g_variant_unref (variant);
+  g_bytes_unref (data2);
+  g_bytes_unref (data1);
+  g_variant_type_free (mv_type);
+}
+
+static void
 test_fuzz (gdouble *fuzziness)
 {
   GVariantSerialised serialised;
@@ -5083,6 +5123,7 @@ main (int argc, char **argv)
   guint i;
 
   g_test_init (&argc, &argv, NULL);
+  g_test_bug_base ("");
 
   g_test_add_func ("/gvariant/type", test_gvarianttype);
   g_test_add_func ("/gvariant/type/string-scan/recursion/tuple",
@@ -5096,6 +5137,7 @@ main (int argc, char **argv)
   g_test_add_func ("/gvariant/serialiser/variant", test_variants);
   g_test_add_func ("/gvariant/serialiser/strings", test_strings);
   g_test_add_func ("/gvariant/serialiser/byteswap", test_byteswaps);
+  g_test_add_func ("/gvariant/serialiser/children", test_serialiser_children);
 
   for (i = 1; i <= 20; i += 4)
     {


### PR DESCRIPTION
Backport two patches from upstream https://gitlab.gnome.org/GNOME/glib/merge_requests/1142 to fix permissions handling in `g_file_copy()` when using the flag `G_FILE_COPY_TARGET_DEFAULT_PERMS`, which was breaking external-appstream support in gnome-software (https://phabricator.endlessm.com/T27828).

Also backport some other useful fixes which will eventually be released upstream as 2.62.1.