### PR TITLE
T28095 Rebase GLib to 2.62.1 (Debian changes)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,62 @@
-glib2.0 (2.62.0-1endless0) experimental; urgency=medium
+glib2.0 (2.62.1-1) unstable; urgency=medium
 
-  * Rebase on latest Debian experimental packaging of 2.62.0 (T27893)
-    + Dropped the following patch which was dropped in upstream Debian packaging:
-      - debian/patches/debian/Disable-an-optimization-when-building-with-gcc-9.patch
+  * Team upload
+  * d/watch: Only watch for even-numbered (stable) releases
+  * New upstream release
+    - Fix regression that made G_FILE_COPY_TARGET_DEFAULT_PERMS result in
+      private permissions rather than respecting umask (Closes: #505398)
+    - d/p/g_file_info_get_modification_date_time-Calculate-in-integ.patch,
+      d/p/Always-build-tests-if-we-enabled-installed-tests.patch:
+      Drop patches that were applied upstream
+  * d/p/debian/mimeapps-test-Mark-as-flaky.patch:
+    Mark mimeapps test as flaky (see #941550)
 
- -- Philip Withnall <withnall@endlessm.com>  Tue, 24 Sep 2019 16:46:00 +0100
+ -- Simon McVittie <smcv@debian.org>  Mon, 07 Oct 2019 09:46:24 +0100
+
+glib2.0 (2.62.0-3) unstable; urgency=medium
+
+  * Team upload
+  * Merge packaging from 2.60.x branch previously in unstable
+    - No changes since 2.62.0-2, except in d/changelog
+    - d/p/debian/Disable-an-optimization-when-building-with-gcc-9.patch:
+      Remove workaround for #931921, which turned out to be a clutter bug
+  * d/p/Always-build-tests-if-we-enabled-installed-tests.patch:
+    Add patch to fix installation of installed-tests in cross-builds
+    (Closes: #941509)
+  * d/p/g_file_info_get_modification_date_time-Calculate-in-integ.patch:
+    Add patch to fix intermittent g-file-info test failures on i386
+    (Closes: #941547)
+  * libglib2.0-dev: Suggest libgirepository1.0-dev, for the GIR files
+    (Closes: #914152)
+  * d/gbp.conf: Use debian/master branch
+  * Standards-Version: 4.4.1 (no changes required)
+
+ -- Simon McVittie <smcv@debian.org>  Wed, 02 Oct 2019 09:13:12 +0100
+
+glib2.0 (2.60.6-2) unstable; urgency=medium
+
+  * Team upload
+  * d/rules: Edit debcrossgen output instead of using a modified version.
+    This fixes use of CFLAGS, etc. during cross-compilation.
+    (Closes: #933560)
+  * Remove obsolete permissions fixing.
+    Issue 1539 was fixed upstream.
+  * d/p/debian/Disable-an-optimization-when-building-with-gcc-9.patch:
+    Disable an optimization when building with gcc-9, instead of forcing
+    gcc-8. This avoids depending on an old gcc, and should be easier to
+    deal with for cross-compilation. (Workaround for #931921)
+  * d/p/gmessages-Only-use-structured-logs-if-GLIB_VERSION_MAX_AL.patch:
+    Update to upstream glib-2-60 branch at commit 2.60.6-2-ga365528f6
+    - Don't use structured logging if GLIB_VERSION_MAX_ALLOWED < 2.56
+
+ -- Simon McVittie <smcv@debian.org>  Tue, 13 Aug 2019 10:32:40 +0100
+
+glib2.0 (2.62.0-2) unstable; urgency=medium
+
+  * Team upload.
+  * Upload to unstable. (Closes: #940161)
+
+ -- Andreas Henriksson <andreas@fatal.se>  Mon, 30 Sep 2019 12:33:16 +0200
 
 glib2.0 (2.62.0-1) experimental; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+glib2.0 (2.62.1-1endless0) unstable; urgency=medium
+
+  * Rebase on latest Debian master packaging of 2.62.1 (T28095)
+    + Added the following patch which was added in upstream Debian packaging:
+      - debian/patches/debian/mimeapps-test-Mark-as-flaky.patch
+    + Added some patches from upstream/glib-2-62 which will form part of the
+      2.62.2 release:
+      - 921471797 Fix use-after-free when calling g_dbus_connection_flush_sync()
+      - 670d6d390 build: no --export-dynamic ldflags for Solaris
+      - 8e49fba3f gunixmounts: Handle Solaris name of mnt_mntopts in place of mnt_opts
+      - 32fe7ad93 gwinhttpvfs: Handle g_get_prgname() returning NULL
+    + Added a new patch to fix the tests when building under `toolbox`,
+      forwarded upstream as https://gitlab.gnome.org/GNOME/glib/merge_requests/1168
+
+ -- Philip Withnall <withnall@endlessm.com>  Wed, 16 Oct 2019 14:55:00 +0100
+
 glib2.0 (2.62.1-1) unstable; urgency=medium
 
   * Team upload

--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,7 @@ Build-Depends: dbus <!nocheck>,
                xterm <!nocheck>,
                zlib1g-dev
 Rules-Requires-Root: no
-Standards-Version: 4.4.0
+Standards-Version: 4.4.1
 Homepage: http://www.gtk.org/
 Vcs-Browser: https://salsa.debian.org/gnome-team/glib/tree/debian/experimental
 Vcs-Git: https://salsa.debian.org/gnome-team/glib.git -b debian/experimental
@@ -127,7 +127,8 @@ Depends: libffi-dev (>= 3.0.0),
          ${shlibs:Depends}
 Breaks: libglib2.0-0-dbg (<< 2.51.4-1~)
 Replaces: libglib2.0-0-dbg (<< 2.51.4-1~)
-Suggests: libglib2.0-doc
+Suggests: libgirepository1.0-dev (>= 1.62),
+          libglib2.0-doc
 Description: Development files for the GLib library
  GLib is a library containing many useful C routines for things such
  as trees, hashes, lists, and strings.  It is a useful general-purpose
@@ -136,6 +137,9 @@ Description: Development files for the GLib library
  This package is needed to compile programs against libglib2.0-0,
  as only it includes the header files and static libraries (optionally)
  needed for compiling.
+ .
+ GObject-Introspection metadata for this library can be found in the
+ libgirepository1.0-dev package.
 
 Package: libglib2.0-dev-bin
 Section: libdevel

--- a/debian/control.in
+++ b/debian/control.in
@@ -34,7 +34,7 @@ Build-Depends: dbus <!nocheck>,
                xterm <!nocheck>,
                zlib1g-dev
 Rules-Requires-Root: no
-Standards-Version: 4.4.0
+Standards-Version: 4.4.1
 Homepage: http://www.gtk.org/
 Vcs-Browser: https://salsa.debian.org/gnome-team/glib/tree/debian/experimental
 Vcs-Git: https://salsa.debian.org/gnome-team/glib.git -b debian/experimental
@@ -123,7 +123,8 @@ Depends: libffi-dev (>= 3.0.0),
          ${shlibs:Depends}
 Breaks: libglib2.0-0-dbg (<< 2.51.4-1~)
 Replaces: libglib2.0-0-dbg (<< 2.51.4-1~)
-Suggests: libglib2.0-doc
+Suggests: libgirepository1.0-dev (>= 1.62),
+          libglib2.0-doc
 Description: Development files for the GLib library
  GLib is a library containing many useful C routines for things such
  as trees, hashes, lists, and strings.  It is a useful general-purpose
@@ -132,6 +133,9 @@ Description: Development files for the GLib library
  This package is needed to compile programs against libglib2.0-0,
  as only it includes the header files and static libraries (optionally)
  needed for compiling.
+ .
+ GObject-Introspection metadata for this library can be found in the
+ libgirepository1.0-dev package.
 
 Package: libglib2.0-dev-bin
 Section: libdevel

--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,6 +1,6 @@
 [DEFAULT]
 pristine-tar = True
-debian-branch = debian/experimental
+debian-branch = debian/master
 upstream-branch = upstream/latest
 upstream-vcs-tag = %(version)s
 

--- a/debian/patches/debian/61_glib-compile-binaries-path.patch
+++ b/debian/patches/debian/61_glib-compile-binaries-path.patch
@@ -11,7 +11,7 @@ Forwarded: not-needed, specific to Debian packaging
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/gio/meson.build b/gio/meson.build
-index 9a9e621..31e1d29 100644
+index 173000f..8507c24 100644
 --- a/gio/meson.build
 +++ b/gio/meson.build
 @@ -833,7 +833,7 @@ pkg.generate(libgio,

--- a/debian/patches/debian/Look-for-gio-launch-desktop-in-libdir-glib-2.0.patch
+++ b/debian/patches/debian/Look-for-gio-launch-desktop-in-libdir-glib-2.0.patch
@@ -29,7 +29,7 @@ index a484c63..5e582f5 100644
          }
  
 diff --git a/gio/meson.build b/gio/meson.build
-index 31e1d29..5044b01 100644
+index 8507c24..8ee2fd9 100644
 --- a/gio/meson.build
 +++ b/gio/meson.build
 @@ -1,6 +1,7 @@

--- a/debian/patches/debian/gvariant-test-Don-t-run-at-build-time-on-mips.patch
+++ b/debian/patches/debian/gvariant-test-Don-t-run-at-build-time-on-mips.patch
@@ -16,10 +16,10 @@ Forwarded: no
  1 file changed, 8 insertions(+)
 
 diff --git a/glib/tests/gvariant.c b/glib/tests/gvariant.c
-index ce413be..c4bf0e7 100644
+index 927ae4e..47808d6 100644
 --- a/glib/tests/gvariant.c
 +++ b/glib/tests/gvariant.c
-@@ -2365,6 +2365,14 @@ test_fuzzes (gpointer data)
+@@ -2405,6 +2405,14 @@ test_fuzzes (gpointer data)
    gdouble fuzziness;
    int i;
  

--- a/debian/patches/debian/mimeapps-test-Mark-as-flaky.patch
+++ b/debian/patches/debian/mimeapps-test-Mark-as-flaky.patch
@@ -1,0 +1,100 @@
+From: Simon McVittie <smcv@debian.org>
+Date: Mon, 7 Oct 2019 09:13:20 +0100
+Subject: mimeapps test: Mark as flaky
+
+This test has a known race condition, tracked upstream at
+<https://gitlab.gnome.org/GNOME/glib/issues/1903>.
+
+Signed-off-by: Simon McVittie <smcv@debian.org>
+Forwarded: no
+---
+ gio/tests/mimeapps.c | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/gio/tests/mimeapps.c b/gio/tests/mimeapps.c
+index 08bcce2..9ef982c 100644
+--- a/gio/tests/mimeapps.c
++++ b/gio/tests/mimeapps.c
+@@ -118,6 +118,12 @@ setup (Fixture       *fixture,
+   gint res;
+   GError *error = NULL;
+ 
++  if (g_getenv ("DEB_ALLOW_FLAKY_TESTS") == NULL)
++    {
++      g_test_skip ("known race condition, #941550");
++      return;
++    }
++
+   /* These are already set to a temporary directory through our use of
+    * %G_TEST_OPTION_ISOLATE_DIRS below. */
+   xdgdatahome = g_get_user_data_dir ();
+@@ -211,6 +217,9 @@ test_mime_api (Fixture       *fixture,
+   GList *list;
+   const gchar *contenttype = "application/pdf";
+ 
++  if (g_test_failed ())
++    return;
++
+   /* clear things out */
+   g_app_info_reset_type_associations (contenttype);
+ 
+@@ -305,6 +314,9 @@ test_mime_file (Fixture       *fixture,
+   GList *list;
+   const gchar *contenttype = "application/pdf";
+ 
++  if (g_test_failed ())
++    return;
++
+   /* clear things out */
+   g_app_info_reset_type_associations (contenttype);
+ 
+@@ -422,6 +434,9 @@ test_mime_default (Fixture       *fixture,
+   GList *list;
+   const gchar *contenttype = "image/png";
+ 
++  if (g_test_failed ())
++    return;
++
+   /* clear things out */
+   g_app_info_reset_type_associations (contenttype);
+ 
+@@ -499,6 +514,9 @@ test_mime_default_last_used (Fixture       *fixture,
+   GList *list;
+   const gchar *contenttype = "image/bmp";
+ 
++  if (g_test_failed ())
++    return;
++
+   /* clear things out */
+   g_app_info_reset_type_associations (contenttype);
+ 
+@@ -591,6 +609,9 @@ test_scheme_handler (Fixture       *fixture,
+ {
+   GAppInfo *info, *info5;
+ 
++  if (g_test_failed ())
++    return;
++
+   info5 = (GAppInfo*)g_desktop_app_info_new ("myapp5.desktop");
+   info = g_app_info_get_default_for_uri_scheme ("ftp");
+   g_assert_true (g_app_info_equal (info, info5));
+@@ -607,6 +628,9 @@ test_mime_ignore_nonexisting (Fixture       *fixture,
+ {
+   GAppInfo *appinfo;
+ 
++  if (g_test_failed ())
++    return;
++
+   appinfo = (GAppInfo*)g_desktop_app_info_new ("nosuchapp.desktop");
+   g_assert_null (appinfo);
+ }
+@@ -617,6 +641,9 @@ test_all (Fixture       *fixture,
+ {
+   GList *all, *l;
+ 
++  if (g_test_failed ())
++    return;
++
+   all = g_app_info_get_all ();
+ 
+   for (l = all; l; l = l->next)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -12,3 +12,4 @@ debian/Skip-test-which-performs-some-unreliable-floating-point-c.patch
 debian/Skip-unreliable-test_threaded_singleton-by-default.patch
 debian/gmenumodel-test-Mark-as-flaky.patch
 debian/gvariant-test-Don-t-run-at-build-time-on-mips.patch
+debian/mimeapps-test-Mark-as-flaky.patch

--- a/debian/tests/flaky
+++ b/debian/tests/flaky
@@ -28,6 +28,7 @@ exec dbus-run-session -- xvfb-run -a gnome-desktop-testing-runner \
 	glib/gdbus-threading.test \
 	glib/gmenumodel.test \
 	glib/mainloop.test \
+	glib/mimeapps.test \
 	glib/socket.test \
 	glib/timeout.test \
 	glib/timer.test \

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
 version=4
-https://download.gnome.org/sources/glib/([\d\.]+)/ \
+https://download.gnome.org/sources/glib/([\d\.]+[02468])/ \
 	glib@ANY_VERSION@\.tar\.xz


### PR DESCRIPTION
Trivial packaging update.

Main pull request is in https://github.com/endlessm/glib/pull/68.

https://phabricator.endlessm.com/T28095