### PR TITLE
GThread - Check if sched_setattr is allowed by the system policies be…

### DIFF
--- a/glib/gthread-posix.c
+++ b/glib/gthread-posix.c
@@ -1211,6 +1211,19 @@ g_system_thread_get_scheduler_settings (GThreadSchedulerSettings *scheduler_sett
     }
   while (res == -1);
 
+  /* Try setting them on the current thread to see if any system policies are
+   * in place that would disallow doing so */
+  res = syscall (SYS_sched_setattr, tid, scheduler_settings->attr, flags);
+  if (res == -1)
+    {
+      int errsv = errno;
+
+      g_debug ("Failed to set thread scheduler attributes: %s", g_strerror (errsv));
+      g_free (scheduler_settings->attr);
+
+      return FALSE;
+    }
+
   return TRUE;
 #else
   return FALSE;


### PR DESCRIPTION
…fore depending on it

On Fedora it's apparently not allowed so we'll have to fall back to the
thread-spawner thread in GThreadPool instead.

---

Trivial backport of https://gitlab.gnome.org/GNOME/glib/merge_requests/1356 to our GLib branch. It’ll be included in the upstream 2.63.6 release and we can drop it then. This should fix crashes in Tracker, Mogwai and other sandboxed services: https://phabricator.endlessm.com/T29303#802066